### PR TITLE
Multi choice without screen clear

### DIFF
--- a/ishell.go
+++ b/ishell.go
@@ -509,7 +509,7 @@ func (s *Shell) multiChoice(options []string, text string, init []int, multiResu
 			strs = strs[offset : maxRows+offset-1]
 		}
 		// move the cursor up to keep the output in place
-		s.Printf("\033[%dA", optionLen*2)
+		s.Printf("\r\033[%dA", optionLen*2)
 		// clear from the cursor to the end of the screen
 		s.Print("\033[0J")
 		s.Println(text)
@@ -524,7 +524,7 @@ func (s *Shell) multiChoice(options []string, text string, init []int, multiResu
 			if cur >= maxRows+offset-1 {
 				offset++
 			}
-			if cur >= len(options) {
+			if cur >= optionLen {
 				offset = fd
 				cur = 0
 			}
@@ -534,12 +534,12 @@ func (s *Shell) multiChoice(options []string, text string, init []int, multiResu
 				offset--
 			}
 			if cur < 0 {
-				if len(options) > maxRows-1 {
-					offset = len(options) - maxRows + 1
+				if optionLen > maxRows-1 {
+					offset = optionLen - maxRows + 1
 				} else {
 					offset = fd
 				}
-				cur = len(options) - 1
+				cur = optionLen - 1
 			}
 		} else if key == -3 {
 			if multiResults {


### PR DESCRIPTION
This is to make it so that triggering a multiChoice/List of options does not clear the screen.

This is not quite there yet, still need to figure out how to stop it from overwriting previous lines when reaching the bottom of the screen. I'm thinking it's because the output would dip below the screen edge, and it doesn't like that.. need to read up on escape sequences some more I guess.
I've also made it so that the space bar is not usable unless it's a checklist/multiSelect.

I haven't tested enough with long lists of options, though. Or with a multiSelect. Need more thorough testing.

### Before
![peek 2018-06-18 11-22](https://user-images.githubusercontent.com/2597514/41533494-79414a22-72ea-11e8-88a0-4b900c49fb63.gif)

### After
![peek 2018-06-18 11-25](https://user-images.githubusercontent.com/2597514/41533507-7d7a672c-72ea-11e8-8616-2294bf82fed2.gif)
![peek 2018-07-02 18-04](https://user-images.githubusercontent.com/2597514/42179171-7e0e82fc-7e22-11e8-9f7c-ebb29fcaaf83.gif)

### TODO:
- [x] No longer clear screen
- [x] Variable option length
- [x] "Scrolling" of question/title line of multiChoice
- [x] Disable space bar when not a checklist
- [x] Avoid overwriting previous lines when toggling options in Checklist
- [x] Avoid overwriting previous lines when at bottom of screen
- [ ] Tests. Tests. Tests.