### PR TITLE
Locked and connected checklist options implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 example/example
 .idea/
 *.iml
+
+#vim
+*.swp
+*.swo

--- a/actions.go
+++ b/actions.go
@@ -42,7 +42,7 @@ type Actions interface {
 	MultiChoice(options []string, text string) int
 	// Checklist is similar to MultiChoice but user can choose multiple variants using Space.
 	// init is initially selected options.
-	Checklist(options []string, text string, init []int) []int
+	Checklist(options []string, text string, multiOpts MultiOptions) []int
 	// SetPrompt sets the prompt string. The string to be displayed before the cursor.
 	SetPrompt(prompt string)
 	// SetMultiPrompt sets the prompt string used for multiple lines. The string to be displayed before
@@ -117,11 +117,11 @@ func (s *shellActionsImpl) Printf(format string, val ...interface{}) {
 }
 
 func (s *shellActionsImpl) MultiChoice(options []string, text string) int {
-	choice := s.multiChoice(options, text, nil, false)
+	choice := s.multiChoice(options, text, MultiOptions{}, false)
 	return choice[0]
 }
-func (s *shellActionsImpl) Checklist(options []string, text string, init []int) []int {
-	return s.multiChoice(options, text, init, true)
+func (s *shellActionsImpl) Checklist(options []string, text string, multiOpts MultiOptions) []int {
+	return s.multiChoice(options, text, multiOpts, true)
 }
 func (s *shellActionsImpl) SetPrompt(prompt string) {
 	s.reader.prompt = prompt


### PR DESCRIPTION
### Checklist locked/connected fields
This is to add the ability to have some fields in a checklist that cannot be unchecked (e.g. mandatory fields, soon-to-be-implemented features that shouldn't be selectable yet but for some reason you want the field visible, etc.), as well as fields that disable one another (i.e. read only vs. read/write).

##### Some examples
![screenshot_2018-07-09_14-16-03](https://user-images.githubusercontent.com/2597514/42455883-f6c23d6e-8382-11e8-8d1a-ed388d1806f6.png)
![screenshot_2018-07-09_14-16-28](https://user-images.githubusercontent.com/2597514/42455884-fa30eb08-8382-11e8-84a6-3185a7e4f2e5.png)

---

`MultiOptions` struct is to be passed as an argument to `Checklist`, denoting which of the options you want; initial selection, locked selections and what selections are connected.

##### Examples
```golang
options := ishell.MultiOptions{Initial: []int{0, 1}, Locked: []int{0, 1}}
````
This indicates an initial selection of the first 2 fields in the checklist that are also the ones that are locked and cannot be deselected.

```golang
connected := map[int][]int{
   2: []int{3},
   3: []int{2},
}
options := ishell.MultiOptions{Connected: connected}
```
This indicates fields that are connected and thus mutually exclusive. When field 2 is selected, field 3 becomes unselectable, and vice versa.

```golang
connected := map[int][]int{
   3: []int{0, 1, 2},
}
options := ishell.MultiOptions{Connected: connected}
```
This indicates a field that is connected to 3 others. If the first 3 fields are selected and then the 4th is selected, this causes the first 3 fields to be deselected and locked out, becoming unselectable.